### PR TITLE
do not wait for data from timebox on connect

### DIFF
--- a/server/src/services/timebox.ts
+++ b/server/src/services/timebox.ts
@@ -13,19 +13,14 @@ export class Timebox {
     }
 
     connect = async (): Promise<void> => {
-        let first = true;
         return new Promise((res, rej) => {
             this.bt.findSerialPortChannel(this.mac, (port) => {
                 this.bt.connect(this.mac, port, () => {
-                    this.bt.on('data', (buffer: Buffer) => {
-                        if (first) {
-                            first = false;
-                            res();
-                        }
-                    });
                     this.bt.on('data', this.onData);
                     this.bt.on('closed', this.disconnect);
                     this.bt.on('failure', this.disconnect);
+
+                    res();
                 }, rej);
             }, () => rej(`can not connect to ${this.mac}`));
         })


### PR DESCRIPTION
Hello noeRls, thank you for your work on the Timebox Evo server and integration! 

When trying your code, I had an issue, that my Timebox Evo does not send  any data on connect, which would mean, that the connect request would timeout, as the Promise was never resolved.
Maybe there are differences between different firmware versions on it?  Resolving the Promise directly on connect, makes it work perfectly fine for me.
