### PR TITLE
Fallback message parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,10 @@ Here come the fun part, here is the list of possibility:
 - displaying image from url
 - displaying image from a local image
 - changing the brightness
+- displaying scrolling text
 - switching to time channel
 
-This custom component acts as a notify platform. This means that the Service Data requires a message parameter, even though we're not using it. Leave the message parameter blank, and specify TimeBox mode and other information in the data parameter of the Service Data payload.
+This custom component acts as a notify platform. This means that the Service Data requires a message parameter, even though we're not using it in all cases. Leave the message parameter blank, and specify TimeBox mode and other information in the data parameter of the Service Data payload.
 
 ## Display an image
 
@@ -145,6 +146,14 @@ Change the brightness on a scale of 0 to 100
     "mode": "text",
     "text": "Hello, World!"
   }
+}
+```
+
+## Display text (message parameter only)
+If you only specify the message parameter, but leave the Service Data empty, it will automatically choose the text mode and display the message.
+```
+{
+  "message": "Hello again, World!"
 }
 ```
 

--- a/timebox/notify.py
+++ b/timebox/notify.py
@@ -73,11 +73,16 @@ class TimeboxService(BaseNotificationService):
             return False
 
     def send_message(self, message="", **kwargs):
-        if kwargs.get(ATTR_DATA) is None:
+        if kwargs.get(ATTR_DATA) is not None:
+            data = kwargs.get(ATTR_DATA)
+            mode = data.get(PARAM_MODE, MODE_TEXT)
+        elif message is not None:
+            data = {}
+            mode = MODE_TEXT
+        else:
             _LOGGER.error("Service call needs a message type")
             return False
-        data = kwargs.get(ATTR_DATA)
-        mode = data.get(PARAM_MODE, MODE_TEXT)
+
         if (mode == MODE_IMAGE):
             if (data.get(PARAM_LINK)):
                 return self.send_image_link(data.get(PARAM_LINK))

--- a/timebox/notify.py
+++ b/timebox/notify.py
@@ -87,11 +87,11 @@ class TimeboxService(BaseNotificationService):
                 _LOGGER.error(f'Invalid payload, {PARAM_LINK} or {PARAM_FILE_NAME} must be provided with {MODE_IMAGE} mode')
                 return False
         elif (mode == MODE_TEXT):
-            text = data.get(PARAM_TEXT)
+            text = data.get(PARAM_TEXT, message)
             if (text):
                 return self.timebox.send_text(text)
             else:
-                _LOGGER.error(f"Invalid payload, {PARAM_TEXT} must be provided with {MODE_TEXT}")
+                _LOGGER.error(f"Invalid payload, {PARAM_TEXT} or message must be provided with {MODE_TEXT}")
                 return False
         elif (mode == MODE_BRIGHTNESS):
             try:

--- a/timebox/notify.py
+++ b/timebox/notify.py
@@ -77,7 +77,7 @@ class TimeboxService(BaseNotificationService):
             _LOGGER.error("Service call needs a message type")
             return False
         data = kwargs.get(ATTR_DATA)
-        mode = data.get(PARAM_MODE)
+        mode = data.get(PARAM_MODE, MODE_TEXT)
         if (mode == MODE_IMAGE):
             if (data.get(PARAM_LINK)):
                 return self.send_image_link(data.get(PARAM_LINK))


### PR DESCRIPTION
I added fallbacks to text mode and the message parameter. This way, the notify service can be used "normally" with the message parameter and should behave like other notify service/integrations as well.